### PR TITLE
Handle IAC packets (eg GMCP/MSSP) without utf-8 decode errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+/build/

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,9 @@ package_dir =
     = src
 packages = find:
 python_requires = >=3.6
+install_requires = 
+    mudtelnet
+
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This adds a dependency, but it's better than reinventing the wheel.

I didn't wire up any handlers, so the we don't actually support any fancy functionality.  It simply means we don't crash when trying to decode `\xff\xfb`.

Also, my IDE trimmed a lot of trailing whitespace, which makes the diff a bit messy, let me know if you want me to recreate the PR without it.